### PR TITLE
don't display two labels when displayLabels = true on multichoice

### DIFF
--- a/remoteform.js
+++ b/remoteform.js
@@ -956,9 +956,12 @@ function remoteForm(config) {
     // One label for the collection (we include a label even if
     // cfg.displayLabels is false becaues there is no other way to show it.
     var label = document.createElement('label');
-    label.className = cfg.css.label;
-    label.innerHTML = def.title;
-    collectionDiv.appendChild(label);
+    // Always create a label, but don't create two if we already display labels.
+    if (cfg.displayLabels !== true) {
+      label.className = cfg.css.label;
+      label.innerHTML = def.title;
+      collectionDiv.appendChild(label);
+    }
     
     // Another div to enclose just the options.
     var optionsDiv = document.createElement('div');


### PR DESCRIPTION
On checkbox/radio rendering, you're always displaying a label.  Which makes sense, but if `displayLabels` is `true`, you end up with two labels.  Attached are before/after screenshots.  To test, just add `displayLabels: true` to your options JSON with a page that has radio/checkbox options.

Now, this page doesn't ACTUALLY have checkbox/radio options, but I think I saw something in the docs about that scenario, so I'll check that out next.

**Before**
![selection_688](https://user-images.githubusercontent.com/1796012/49176938-f8e09580-f319-11e8-9a9b-d1e43f31b184.png)
**After**
![selection_689](https://user-images.githubusercontent.com/1796012/49176937-f8e09580-f319-11e8-9462-e51333bd7cb7.png)

