### PR TITLE
Non-price set radio buttons don't render

### DIFF
--- a/remoteform.js
+++ b/remoteform.js
@@ -1065,7 +1065,7 @@ function remoteForm(config) {
           }
         }
         else {
-          optionDisplay = def.options[option];
+          optionDisplay = def.options[optionId];
         }
 
         optionInput.value = optionId;


### PR DESCRIPTION
If you have a profile field that's not a price set but IS radio buttons (and presumably checkboxes as well) the field will fail to render and you'll get the error that `option` is undefined.  It should be `optionId`.