### PR TITLE
When Civi has no labels, remoteform displays "null"

### DIFF
--- a/remoteform.js
+++ b/remoteform.js
@@ -1048,7 +1048,8 @@ function remoteForm(config) {
             });
           }
           else {
-            optionDisplay = optionObj['label'] + ' (' + prefix + parseFloat(optionObj['amount']).toFixed(2) + ')';
+            optionDisplay = optionObj['label'] ? optionObj['label'] + ' - ' : '';
+            optionDisplay += prefix + parseFloat(optionObj['amount']).toFixed(2);
             optionInput.setAttribute('data-amount', optionObj['amount']);
             if (pricesetHasOtherAmountOption) {
               // This is not an other amount field, but since there is 


### PR DESCRIPTION
Again, here are some before/after screenshots:
**Before**
![selection_690](https://user-images.githubusercontent.com/1796012/49179137-9ee2ce80-f31f-11e8-9632-98ef7e93b2b2.png)
**After**
![selection_691](https://user-images.githubusercontent.com/1796012/49179136-9ee2ce80-f31f-11e8-9c6f-ddda70d3c742.png)

I switched from parentheses to a dash, which is a bit opinionated, but mirrors the regular CiviCRM forms.  If you don't like that you can always change it.