### PR TITLE
Add support for richtexteditor fields

### DIFF
--- a/remoteform.js
+++ b/remoteform.js
@@ -896,6 +896,7 @@ function remoteForm(config) {
       case 'radio':
         return createCheckboxesOrRadios(key, def, type);
       case 'textarea':
+      case 'richtexteditor':
         return createTextArea(key, def);
       case 'hidden':
         return null;


### PR DESCRIPTION
For example, an "activity details" field (when used in combination with the [activityprofile](https://lab.civicrm.org/extensions/activityprofile) extension).

It does not display the WYSIWYG editor, but it's better than a one-line input.