### PR TITLE
Fix PHP8.2 compatibility

### DIFF
--- a/remoteform.php
+++ b/remoteform.php
@@ -257,7 +257,7 @@ function remoteform_add_enable_field($form, $name, $label, $code) {
 
   // dynamically insert a template block in the page
   CRM_Core_Region::instance('page-body')->add(array(
-    'template' => "{$templatePath}/${name}.tpl"
+    'template' => "{$templatePath}/{$name}.tpl"
   ));
   $id = intval($form->getVar('_id'));
 


### PR DESCRIPTION
Fixes this deprecation warning seen on PHP 8.2:

```
[PHP Deprecation] Using ${var} in strings is deprecated, use {$var} instead at remoteform.php:261
```

cc @jmcclelland 