### PR TITLE
Fix label htmlFor attribute

### DIFF
--- a/remoteform.js
+++ b/remoteform.js
@@ -952,7 +952,7 @@ function remoteForm(config) {
       // sr_only will hide except for screen readers.
       label.className = cfg.css.sr_only;
     }
-    label.for = key;
+    label.htmlFor = key;
     label.innerHTML = def.title;
     div.appendChild(label);
 
@@ -1155,7 +1155,7 @@ function remoteForm(config) {
 
         // Create the label.
         var optionLabel = document.createElement('label');
-        optionLabel.for = optionInput.id; 
+        optionLabel.htmlFor = optionInput.id;
 
         // We have both simple options (the label is the value, e.g.
         // options = [ { key: label }, { key: label} ] and also 


### PR DESCRIPTION
Fixes the `for` attribute on labels.

Ex:

- Create custom field with a single checkbox option (ex: "I consent to a bunch of legalese I won't be bothered to read")
- Add it to a profile

The checkbox label was not clickable, the `for` attribute was not set.

Using `htmlFor` seems to be the recommended way: https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/htmlFor
