### PR TITLE
fix fatal error on PHP 8+ when no data is received

### DIFF
--- a/CRM/Remoteform/Page/RemoteForm.php
+++ b/CRM/Remoteform/Page/RemoteForm.php
@@ -8,6 +8,9 @@ class CRM_Remoteform_Page_RemoteForm extends CRM_Core_Page {
   public function run() {
     $this->printCorsHeaders();
 		$data = json_decode(stripslashes(file_get_contents("php://input")));
+    if (empty($data)) {
+      $this->exitError(E::ts("No data was received."));
+    }
     try {
       $data = $this->sanitizeInput($data);
     }


### PR DESCRIPTION
Sometimes, bots will hit the remoteform endpoint (https://mysite.org/civicrm/remoteform).  This causes a fatal error to show up in Drupal watchdog.

This only happens in PHP 8+, because passing `null` to `get_object_vars()` results in a fatal.  Not sure why it doesn't bubble up since it's in a try-catch, but this seems like the appropriate fix.